### PR TITLE
Appt 9: Create controllers for Appointments

### DIFF
--- a/server/config/jwt.config.ts
+++ b/server/config/jwt.config.ts
@@ -1,7 +1,7 @@
-const jwt = require("jsonwebtoken");
+import jwt from "jsonwebtoken"
 import { Request, Response, NextFunction } from 'express';
 
-module.exports = {
+export default {
     authenticate(req : Request, res : Response, next : NextFunction){
         jwt.verify(
             req.cookies.usertoken,

--- a/server/controllers/appt.controller.ts
+++ b/server/controllers/appt.controller.ts
@@ -7,7 +7,7 @@ const findAllAppointments = async (req: Request, res: Response): Promise<IAppoin
     const appointments = await Appointment.find()
     return res.status(200).json(appointments)
   } catch(e) {
-    return res.status(500).json(e.message)
+    return res.status(500).json(e)
   }
 }
 
@@ -16,7 +16,7 @@ const createNewAppointment = async (req: Request, res: Response): Promise<IAppoi
     const appointment = await Appointment.create(req.body)
     return res.status(201).json(appointment)
   } catch(e) {
-    return res.status(500).json(e.message)
+    return res.status(500).json(e)
   }
 }
 
@@ -25,7 +25,7 @@ const findOneAppointment = async (req: Request, res: Response): Promise<IAppoint
     const appointment = await Appointment.findOne({ _id: req.params.id })
     return res.status(200).json(appointment)
   } catch(e) {
-    return res.status(500).json(e.message)
+    return res.status(500).json(e)
   }
 }
 const updateAppointment = async (req: Request, res: Response): Promise<IAppointment> => {
@@ -33,7 +33,7 @@ const updateAppointment = async (req: Request, res: Response): Promise<IAppointm
     const appointment = await Appointment.findByIdAndUpdate({ _id: req.params.id }, req.body, { runValidators: true, new: true })
     return res.status(200).json(appointment)
   } catch(e) {
-    return res.status(500).json(e.message)
+    return res.status(500).json(e)
   }
 }
 const deleteAppointment = async (req: Request, res: Response): Promise<{}> => {
@@ -41,7 +41,7 @@ const deleteAppointment = async (req: Request, res: Response): Promise<{}> => {
     const appointment = await Appointment.deleteOne({ _id: req.params.id })
     return res.status(200).json(appointment)
   } catch(e) {
-    return res.status(500).json(e.message)
+    return res.status(500).json(e)
   }
 }
 

--- a/server/controllers/appt.controller.ts
+++ b/server/controllers/appt.controller.ts
@@ -1,0 +1,26 @@
+import { Request, Response } from "express";
+import Appointment from "../models/appt.model";
+
+const findAllAppointments = async (req: Request, res: Response) => {
+  try {
+    const appointments = await Appointment.find()
+    return res.status(200)
+  } catch(e) {
+    return res.status(500).send(e.message)
+  }
+}
+
+const createNewAppointment = async (req: Request, res: Response) => {
+  try {
+    const appointment = await Appointment.create()
+    return res.status(200)
+  } catch(e) {
+    return res.status(500).send(e.message)
+  }
+}
+
+const findOneAppointment = async (req: Request, res: Response) => {}
+const updateAppointment = async (req: Request, res: Response) => {}
+const deleteAppointment = async (req: Request, res: Response) => {}
+
+export { findAllAppointments, createNewAppointment, findOneAppointment, updateAppointment, deleteAppointment }

--- a/server/controllers/appt.controller.ts
+++ b/server/controllers/appt.controller.ts
@@ -4,7 +4,7 @@ import Appointment from "../models/appt.model";
 const findAllAppointments = async (req: Request, res: Response) => {
   try {
     const appointments = await Appointment.find()
-    return res.status(200)
+    return res.status(200).send(appointments)
   } catch(e) {
     return res.status(500).send(e.message)
   }
@@ -12,15 +12,36 @@ const findAllAppointments = async (req: Request, res: Response) => {
 
 const createNewAppointment = async (req: Request, res: Response) => {
   try {
-    const appointment = await Appointment.create()
-    return res.status(200)
+    const appointment = await Appointment.create(req.body)
+    return res.status(201).send(appointment)
   } catch(e) {
     return res.status(500).send(e.message)
   }
 }
 
-const findOneAppointment = async (req: Request, res: Response) => {}
-const updateAppointment = async (req: Request, res: Response) => {}
-const deleteAppointment = async (req: Request, res: Response) => {}
+const findOneAppointment = async (req: Request, res: Response) => {
+  try {
+    const appointment = await Appointment.findOne({ _id: req.params.id })
+    return res.status(200).send(appointment)
+  } catch(e) {
+    return res.status(500).send(e.message)
+  }
+}
+const updateAppointment = async (req: Request, res: Response) => {
+  try {
+    const appointment = await Appointment.findByIdAndUpdate({ _id: req.params.id }, req.body, { new: true })
+    return res.status(200).send(appointment)
+  } catch(e) {
+    return res.status(500).send(e.message)
+  }
+}
+const deleteAppointment = async (req: Request, res: Response) => {
+  try {
+    const appointment = await Appointment.deleteOne({ _id: req.params.id })
+    return res.status(200).send(appointment)
+  } catch(e) {
+    return res.status(500).send(e.message)
+  }
+}
 
 export { findAllAppointments, createNewAppointment, findOneAppointment, updateAppointment, deleteAppointment }

--- a/server/controllers/appt.controller.ts
+++ b/server/controllers/appt.controller.ts
@@ -1,7 +1,8 @@
 import { Request, Response } from "express";
 import Appointment from "../models/appt.model";
+import { IAppointment } from "../interfaces/appointment.interface";
 
-const findAllAppointments = async (req: Request, res: Response) => {
+const findAllAppointments = async (req: Request, res: Response): Promise<IAppointment[]> => {
   try {
     const appointments = await Appointment.find()
     return res.status(200).send(appointments)
@@ -10,7 +11,7 @@ const findAllAppointments = async (req: Request, res: Response) => {
   }
 }
 
-const createNewAppointment = async (req: Request, res: Response) => {
+const createNewAppointment = async (req: Request, res: Response): Promise<IAppointment> => {
   try {
     const appointment = await Appointment.create(req.body)
     return res.status(201).send(appointment)
@@ -19,7 +20,7 @@ const createNewAppointment = async (req: Request, res: Response) => {
   }
 }
 
-const findOneAppointment = async (req: Request, res: Response) => {
+const findOneAppointment = async (req: Request, res: Response): Promise<IAppointment> => {
   try {
     const appointment = await Appointment.findOne({ _id: req.params.id })
     return res.status(200).send(appointment)
@@ -27,7 +28,7 @@ const findOneAppointment = async (req: Request, res: Response) => {
     return res.status(500).send(e.message)
   }
 }
-const updateAppointment = async (req: Request, res: Response) => {
+const updateAppointment = async (req: Request, res: Response): Promise<IAppointment> => {
   try {
     const appointment = await Appointment.findByIdAndUpdate({ _id: req.params.id }, req.body, { new: true })
     return res.status(200).send(appointment)
@@ -35,7 +36,7 @@ const updateAppointment = async (req: Request, res: Response) => {
     return res.status(500).send(e.message)
   }
 }
-const deleteAppointment = async (req: Request, res: Response) => {
+const deleteAppointment = async (req: Request, res: Response): Promise<{}> => {
   try {
     const appointment = await Appointment.deleteOne({ _id: req.params.id })
     return res.status(200).send(appointment)
@@ -44,4 +45,10 @@ const deleteAppointment = async (req: Request, res: Response) => {
   }
 }
 
-export { findAllAppointments, createNewAppointment, findOneAppointment, updateAppointment, deleteAppointment }
+export { 
+  findAllAppointments,
+  createNewAppointment,
+  findOneAppointment,
+  updateAppointment,
+  deleteAppointment
+}

--- a/server/controllers/appt.controller.ts
+++ b/server/controllers/appt.controller.ts
@@ -2,11 +2,13 @@ import { Request, Response } from "express";
 import Appointment from "../models/appt.model";
 import { IAppointment } from "../interfaces/appointment.interface";
 
+type ResultError = { type: 'error'; error: Error }
+
 const findAllAppointments = async (req: Request, res: Response): Promise<IAppointment[]> => {
   try {
     const appointments = await Appointment.find()
     return res.status(200).json(appointments)
-  } catch(e) {
+  } catch(e: unknown) {
     return res.status(500).json(e)
   }
 }
@@ -15,7 +17,7 @@ const createNewAppointment = async (req: Request, res: Response): Promise<IAppoi
   try {
     const appointment = await Appointment.create(req.body)
     return res.status(201).json(appointment)
-  } catch(e) {
+  } catch(e: unknown) {
     return res.status(500).json(e)
   }
 }
@@ -24,7 +26,7 @@ const findOneAppointment = async (req: Request, res: Response): Promise<IAppoint
   try {
     const appointment = await Appointment.findOne({ _id: req.params.id })
     return res.status(200).json(appointment)
-  } catch(e) {
+  } catch(e: unknown) {
     return res.status(500).json(e)
   }
 }
@@ -32,7 +34,7 @@ const updateAppointment = async (req: Request, res: Response): Promise<IAppointm
   try {
     const appointment = await Appointment.findByIdAndUpdate({ _id: req.params.id }, req.body, { runValidators: true, new: true })
     return res.status(200).json(appointment)
-  } catch(e) {
+  } catch(e: unknown) {
     return res.status(500).json(e)
   }
 }
@@ -40,7 +42,7 @@ const deleteAppointment = async (req: Request, res: Response): Promise<{}> => {
   try {
     const appointment = await Appointment.deleteOne({ _id: req.params.id })
     return res.status(200).json(appointment)
-  } catch(e) {
+  } catch(e: unknown) {
     return res.status(500).json(e)
   }
 }

--- a/server/controllers/appt.controller.ts
+++ b/server/controllers/appt.controller.ts
@@ -30,7 +30,7 @@ const findOneAppointment = async (req: Request, res: Response): Promise<IAppoint
 }
 const updateAppointment = async (req: Request, res: Response): Promise<IAppointment> => {
   try {
-    const appointment = await Appointment.findByIdAndUpdate({ _id: req.params.id }, req.body, { new: true })
+    const appointment = await Appointment.findByIdAndUpdate({ _id: req.params.id }, req.body, { runValidators: true, new: true })
     return res.status(200).json(appointment)
   } catch(e) {
     return res.status(500).json(e.message)
@@ -45,7 +45,7 @@ const deleteAppointment = async (req: Request, res: Response): Promise<{}> => {
   }
 }
 
-export { 
+export default { 
   findAllAppointments,
   createNewAppointment,
   findOneAppointment,

--- a/server/controllers/appt.controller.ts
+++ b/server/controllers/appt.controller.ts
@@ -5,43 +5,43 @@ import { IAppointment } from "../interfaces/appointment.interface";
 const findAllAppointments = async (req: Request, res: Response): Promise<IAppointment[]> => {
   try {
     const appointments = await Appointment.find()
-    return res.status(200).send(appointments)
+    return res.status(200).json(appointments)
   } catch(e) {
-    return res.status(500).send(e.message)
+    return res.status(500).json(e.message)
   }
 }
 
 const createNewAppointment = async (req: Request, res: Response): Promise<IAppointment> => {
   try {
     const appointment = await Appointment.create(req.body)
-    return res.status(201).send(appointment)
+    return res.status(201).json(appointment)
   } catch(e) {
-    return res.status(500).send(e.message)
+    return res.status(500).json(e.message)
   }
 }
 
 const findOneAppointment = async (req: Request, res: Response): Promise<IAppointment> => {
   try {
     const appointment = await Appointment.findOne({ _id: req.params.id })
-    return res.status(200).send(appointment)
+    return res.status(200).json(appointment)
   } catch(e) {
-    return res.status(500).send(e.message)
+    return res.status(500).json(e.message)
   }
 }
 const updateAppointment = async (req: Request, res: Response): Promise<IAppointment> => {
   try {
     const appointment = await Appointment.findByIdAndUpdate({ _id: req.params.id }, req.body, { new: true })
-    return res.status(200).send(appointment)
+    return res.status(200).json(appointment)
   } catch(e) {
-    return res.status(500).send(e.message)
+    return res.status(500).json(e.message)
   }
 }
 const deleteAppointment = async (req: Request, res: Response): Promise<{}> => {
   try {
     const appointment = await Appointment.deleteOne({ _id: req.params.id })
-    return res.status(200).send(appointment)
+    return res.status(200).json(appointment)
   } catch(e) {
-    return res.status(500).send(e.message)
+    return res.status(500).json(e.message)
   }
 }
 

--- a/server/controllers/user.controller.ts
+++ b/server/controllers/user.controller.ts
@@ -1,0 +1,8 @@
+import { Request, Response } from "express";
+
+const register = async (req: Request, res: Response) => {}
+const login = async (req: Request, res: Response) => {}
+const logout = async (req: Request, res: Response) => {}
+const getOneUser = async (req: Request, res: Response) => {}
+
+export { register, login, logout, getOneUser }

--- a/server/interfaces/appointment.interface.ts
+++ b/server/interfaces/appointment.interface.ts
@@ -1,0 +1,10 @@
+import { Document } from "mongoose";
+import Appointment from "../models/appt.model";
+
+export interface IAppointment extends Document {
+  name: string;
+  specialty: string;
+  time: string;
+  location: string;
+  notes: string;
+}

--- a/server/interfaces/user.interface.ts
+++ b/server/interfaces/user.interface.ts
@@ -1,0 +1,6 @@
+import { Document } from "mongoose";
+
+export interface IUser extends Document {
+  email: string;
+  password: string;
+}

--- a/server/models/appt.model.ts
+++ b/server/models/appt.model.ts
@@ -19,8 +19,7 @@ const appointmentSchema: Schema = new Schema({
         required: [true, "Location is required"],
     },
     notes: {
-        type: String,
-        required: [true, "Notes are required"],
+        type: String
     },
 }, { timestamps: true });
 

--- a/server/models/appt.model.ts
+++ b/server/models/appt.model.ts
@@ -1,12 +1,5 @@
 import { Document, Model, model, Schema } from "mongoose";
-
-export interface IAppointment extends Document {
-    name: string;
-    specialty: string;
-    time: string;
-    location: string;
-    notes: string;
-}
+import { IAppointment } from "../interfaces/appointment.interface";
 
 const appointmentSchema: Schema = new Schema({
     name: {

--- a/server/models/appt.model.ts
+++ b/server/models/appt.model.ts
@@ -1,4 +1,4 @@
-import { Document, Model, model, Schema } from "mongoose";
+import { Model, model, Schema } from "mongoose";
 import { IAppointment } from "../interfaces/appointment.interface";
 
 const appointmentSchema: Schema = new Schema({

--- a/server/models/appt.model.ts
+++ b/server/models/appt.model.ts
@@ -4,23 +4,23 @@ import { IAppointment } from "../interfaces/appointment.interface";
 const appointmentSchema: Schema = new Schema({
     name: {
         type: String,
-        required: true,
+        required: [true, "Name is required"],
     },
     specialty: {
         type: String,
-        required: true,
+        required: [true, "Speciality is required"],
     },
     time: {
         type: String,
-        required: true
+        required: [true, "Time is required"],
     },
     location: {
         type: String,
-        required: true
+        required: [true, "Location is required"],
     },
     notes: {
         type: String,
-        required: false
+        required: [true, "Notes are required"],
     },
 }, { timestamps: true });
 

--- a/server/models/user.model.ts
+++ b/server/models/user.model.ts
@@ -1,6 +1,5 @@
 import { Document, Model, model, Schema } from "mongoose";
-const bcrypt = require("bcrypt");
-
+import bcrypt from 'bcrypt'
 export interface IUser extends Document {
     email: string;
     password: string;

--- a/server/models/user.model.ts
+++ b/server/models/user.model.ts
@@ -1,9 +1,6 @@
-import { Document, Model, model, Schema } from "mongoose";
-import bcrypt from 'bcrypt'
-export interface IUser extends Document {
-    email: string;
-    password: string;
-}
+import { Model, model, Schema } from "mongoose";
+import bcrypt from "bcrypt"
+import { IUser } from "../interfaces/user.interface";
 
 const UserSchema: Schema = new Schema({
     email: {

--- a/server/package.json
+++ b/server/package.json
@@ -18,5 +18,8 @@
         "express": "^4.17.1",
         "jsonwebtoken": "^8.5.1",
         "mongoose": "^6.1.2"
+    },
+    "devDependencies": {
+        "@types/mongodb": "^4.0.7"
     }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -11,6 +11,7 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
+        "bcrypt": "^5.0.1",
         "config": "^3.3.6",
         "cors": "^2.8.5",
         "dotenv": "^10.0.0",

--- a/server/routes/appt.routes.ts
+++ b/server/routes/appt.routes.ts
@@ -1,5 +1,5 @@
 import { Express } from "express";
-import * as AppointmentController from "../controllers/appt.controller"
+import AppointmentController from "../controllers/appt.controller"
 import authenticate from '../config/jwt.config'
 
 export default (app: Express) => {

--- a/server/routes/appt.routes.ts
+++ b/server/routes/appt.routes.ts
@@ -1,11 +1,11 @@
-const AppointmentController = require("../controllers/appt.controller");
+import { Express } from "express";
+import * as AppointmentController from "../controllers/appt.controller"
+import authenticate from '../config/jwt.config'
 
-const { authenticate } = require("../config/jwt.config");
-
-module.exports = (app : any) =>{
-    app.get("/api/appointments", authenticate, AppointmentController.findAllAppointments);
-    app.post("/api/appointments", authenticate, AppointmentController.createNewAppointment);
-    app.get("/api/appointment/:id", authenticate, AppointmentController.findOneAppointment);
-    app.put("/api/appointment/:id", authenticate, AppointmentController.updateAppointment);
-    app.delete("/api/appointment/:id", authenticate, AppointmentController.deleteAppointment);;
+export default (app: Express) => {
+    app.get("/api/appointments", AppointmentController.findAllAppointments);
+    app.post("/api/appointments", AppointmentController.createNewAppointment);
+    app.get("/api/appointment/:id", AppointmentController.findOneAppointment);
+    app.put("/api/appointment/:id", AppointmentController.updateAppointment);
+    app.delete("/api/appointment/:id", AppointmentController.deleteAppointment);;
 }

--- a/server/routes/routes.config.ts
+++ b/server/routes/routes.config.ts
@@ -1,0 +1,8 @@
+import appt from './appt.routes'
+import user from './user.routes'
+import { Express } from "express";
+
+export default (app: Express) => {
+  appt(app),
+  user(app)
+}

--- a/server/routes/user.routes.ts
+++ b/server/routes/user.routes.ts
@@ -1,6 +1,7 @@
-const UserController = require(`../controllers/user.controller`);
+import { Express } from "express";
+import * as UserController from "../controllers/user.controller"
 
-module.exports = (app : any) => {
+export default (app : Express) => {
     app.post("/api/users/register", UserController.register);
     app.post("/api/users/login", UserController.login);
     app.post("/api/users/logout", UserController.logout);

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import cors from 'cors';
-import './routes/appt.routes';
+import routes from './routes/routes.config';
 import connectDB from './config/mongoose.config';
 const app = express();
 const port = 8000;
@@ -10,5 +10,5 @@ app.use(express.urlencoded({ extended: true }));
 
 // Connect to MongoDB
 connectDB();
-
+routes(app)
 app.listen(port, () => console.log(`Listening on port: ${port}`));

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -2,6 +2,21 @@
 # yarn lockfile v1
 
 
+"@mapbox/node-pre-gyp@^1.0.0":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.8.tgz#32abc8a5c624bc4e46c43d84dfb8b26d33a96f58"
+  integrity sha512-CMGKi28CF+qlbXh26hDe6NxCd7amqeAzEqnS6IHeO6LoaKyM/n+Xw3HT1COdq8cuioOdlKdqn/hCmqPUOMOywg==
+  dependencies:
+    detect-libc "^1.0.3"
+    https-proxy-agent "^5.0.0"
+    make-dir "^3.1.0"
+    node-fetch "^2.6.5"
+    nopt "^5.0.0"
+    npmlog "^5.0.1"
+    rimraf "^3.0.2"
+    semver "^7.3.5"
+    tar "^6.1.11"
+
 "@types/node@*":
   version "17.0.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.0.tgz#62797cee3b8b497f6547503b2312254d4fe3c2bb"
@@ -20,6 +35,11 @@
     "@types/node" "*"
     "@types/webidl-conversions" "*"
 
+abbrev@1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
+  integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+
 accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
@@ -28,15 +48,53 @@ accepts@~1.3.7:
     mime-types "~2.1.24"
     negotiator "0.6.2"
 
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
+
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
+"aproba@^1.0.3 || ^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc"
+  integrity sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==
+
+are-we-there-yet@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz#372e0e7bd279d8e94c653aaa1f67200884bf3e1c"
+  integrity sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==
+  dependencies:
+    delegates "^1.0.0"
+    readable-stream "^3.6.0"
+
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
   integrity sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=
 
+balanced-match@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
 base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
+bcrypt@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/bcrypt/-/bcrypt-5.0.1.tgz#f1a2c20f208e2ccdceea4433df0c8b2c54ecdf71"
+  integrity sha512-9BTgmrhZM2t1bNuDtrtIMVSmmxZBrJ71n8Wg+YgdjHuIWYF7SjjmCPZFB+/5i/o/PIeRpwVJR3P+NrpIItUjqw==
+  dependencies:
+    "@mapbox/node-pre-gyp" "^1.0.0"
+    node-addon-api "^3.1.0"
 
 body-parser@1.19.0:
   version "1.19.0"
@@ -53,6 +111,14 @@ body-parser@1.19.0:
     qs "6.7.0"
     raw-body "2.4.0"
     type-is "~1.6.17"
+
+brace-expansion@^1.1.7:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+  dependencies:
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
 
 bson@^4.2.2, bson@^4.6.0:
   version "4.6.0"
@@ -79,12 +145,32 @@ bytes@3.1.0:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
   integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
 
+chownr@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
+  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
+
+color-support@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
+  integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
+
+concat-map@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+
 config@^3.3.6:
   version "3.3.6"
   resolved "https://registry.yarnpkg.com/config/-/config-3.3.6.tgz#b87799db7399cc34988f55379b5f43465b1b065c"
   integrity sha512-Hj5916C5HFawjYJat1epbyY2PlAgLpBtDUlr0MxGLgo3p5+7kylyvnRY18PqJHgnNWXcdd0eWDemT7eYWuFgwg==
   dependencies:
     json5 "^2.1.1"
+
+console-control-strings@^1.0.0, console-control-strings@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
+  integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
 content-disposition@0.5.3:
   version "0.5.3"
@@ -123,12 +209,17 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4.x:
+debug@4, debug@4.x:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
   integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
   dependencies:
     ms "2.1.2"
+
+delegates@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
+  integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
 denque@^2.0.1:
   version "2.0.1"
@@ -144,6 +235,11 @@ destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
+
+detect-libc@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 dotenv@^10.0.0:
   version "10.0.0"
@@ -161,6 +257,11 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
+
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -236,6 +337,50 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
+fs-minipass@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
+  integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
+  dependencies:
+    minipass "^3.0.0"
+
+fs.realpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+  integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
+
+gauge@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/gauge/-/gauge-3.0.2.tgz#03bf4441c044383908bcfa0656ad91803259b395"
+  integrity sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==
+  dependencies:
+    aproba "^1.0.3 || ^2.0.0"
+    color-support "^1.1.2"
+    console-control-strings "^1.0.0"
+    has-unicode "^2.0.1"
+    object-assign "^4.1.1"
+    signal-exit "^3.0.0"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
+    wide-align "^1.1.2"
+
+glob@^7.1.3:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
+  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+has-unicode@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
+  integrity sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=
+
 http-errors@1.7.2:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.2.tgz#4f5029cf13239f31036e5b2e55292bcfbcc85c8f"
@@ -258,6 +403,14 @@ http-errors@~1.7.2:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
+https-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
+  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
+  dependencies:
+    agent-base "6"
+    debug "4"
+
 iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -270,20 +423,33 @@ ieee754@^1.1.13:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
+inflight@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
+  dependencies:
+    once "^1.3.0"
+    wrappy "1"
+
+inherits@2, inherits@2.0.4, inherits@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
 inherits@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-inherits@2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
-  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
-
 ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
+
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
 json5@^2.1.1:
   version "2.2.0"
@@ -365,6 +531,20 @@ lodash.once@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
+make-dir@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
+  integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
+  dependencies:
+    semver "^6.0.0"
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
@@ -402,10 +582,37 @@ mime@1.6.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
+minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
+minipass@^3.0.0:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.6.tgz#3b8150aa688a711a1521af5e8779c1d3bb4f45ee"
+  integrity sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==
+  dependencies:
+    yallist "^4.0.0"
+
+minizlib@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
+  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
+  dependencies:
+    minipass "^3.0.0"
+    yallist "^4.0.0"
+
+mkdirp@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 mongodb-connection-string-url@^2.3.2:
   version "2.3.2"
@@ -480,7 +687,36 @@ negotiator@0.6.2:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
-object-assign@^4:
+node-addon-api@^3.1.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
+  integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
+
+node-fetch@^2.6.5:
+  version "2.6.6"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.6.tgz#1751a7c01834e8e1697758732e9efb6eeadfaf89"
+  integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+nopt@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-5.0.0.tgz#530942bb58a512fccafe53fe210f13a25355dc88"
+  integrity sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==
+  dependencies:
+    abbrev "1"
+
+npmlog@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-5.0.1.tgz#f06678e80e29419ad67ab964e0fa69959c1eb8b0"
+  integrity sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==
+  dependencies:
+    are-we-there-yet "^2.0.0"
+    console-control-strings "^1.1.0"
+    gauge "^3.0.0"
+    set-blocking "^2.0.0"
+
+object-assign@^4, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -492,10 +728,22 @@ on-finished@~2.3.0:
   dependencies:
     ee-first "1.1.1"
 
+once@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
+  dependencies:
+    wrappy "1"
+
 parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
+
+path-is-absolute@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
 path-to-regexp@0.1.7:
   version "0.1.7"
@@ -535,17 +783,33 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+readable-stream@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
 regexp-clone@1.0.0, regexp-clone@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/regexp-clone/-/regexp-clone-1.0.0.tgz#222db967623277056260b992626354a04ce9bf63"
   integrity sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw==
+
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
 
 safe-buffer@5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@^5.0.1:
+safe-buffer@^5.0.1, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -566,6 +830,18 @@ semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
+
+semver@^6.0.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.5:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
 
 send@0.17.1:
   version "0.17.1"
@@ -596,6 +872,11 @@ serve-static@1.14.1:
     parseurl "~1.3.3"
     send "0.17.1"
 
+set-blocking@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
+  integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
 setprototypeof@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
@@ -605,6 +886,11 @@ sift@13.5.2:
   version "13.5.2"
   resolved "https://registry.yarnpkg.com/sift/-/sift-13.5.2.tgz#24a715e13c617b086166cd04917d204a591c9da6"
   integrity sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA==
+
+signal-exit@^3.0.0:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.6.tgz#24e630c4b0f03fea446a2bd299e62b4a6ca8d0af"
+  integrity sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==
 
 sliced@1.0.1:
   version "1.0.1"
@@ -623,6 +909,41 @@ sparse-bitfield@^3.0.3:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+tar@^6.1.11:
+  version "6.1.11"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
+  integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^3.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
+
 toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
@@ -634,6 +955,11 @@ tr46@^3.0.0:
   integrity sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==
   dependencies:
     punycode "^2.1.1"
+
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
 type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"
@@ -648,6 +974,11 @@ unpipe@1.0.0, unpipe@~1.0.0:
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
 
+util-deprecate@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+
 utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
@@ -657,6 +988,11 @@ vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
 
 webidl-conversions@^7.0.0:
   version "7.0.0"
@@ -670,3 +1006,28 @@ whatwg-url@^11.0.0:
   dependencies:
     tr46 "^3.0.0"
     webidl-conversions "^7.0.0"
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
+
+wide-align@^1.1.2:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.5.tgz#df1d4c206854369ecf3c9a4898f1b23fbd9d15d3"
+  integrity sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==
+  dependencies:
+    string-width "^1.0.2 || 2 || 3 || 4"
+
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -17,6 +17,13 @@
     semver "^7.3.5"
     tar "^6.1.11"
 
+"@types/mongodb@^4.0.7":
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/@types/mongodb/-/mongodb-4.0.7.tgz#ebaa80c53b684ea52ccfe7721c0f5c9ef7b4f511"
+  integrity sha512-lPUYPpzA43baXqnd36cZ9xxorprybxXDzteVKCPAdp14ppHtFJHnXYvNpmBvtMUTb5fKXVv6sVbzo1LHkWhJlw==
+  dependencies:
+    mongodb "*"
+
 "@types/node@*":
   version "17.0.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.0.tgz#62797cee3b8b497f6547503b2312254d4fe3c2bb"
@@ -622,7 +629,7 @@ mongodb-connection-string-url@^2.3.2:
     "@types/whatwg-url" "^8.2.1"
     whatwg-url "^11.0.0"
 
-mongodb@4.2.2:
+mongodb@*, mongodb@4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-4.2.2.tgz#cd70568bd96003877e35358ad17a0c5de35c6dfd"
   integrity sha512-zt8rCTnTKyMQppyt63qMnrLM5dbADgUk18ORPF1XbtHLIYCyc9hattaYHi0pqMvNxDpgGgUofSVzS+UQErgTug==


### PR DESCRIPTION
- First iteration of CRUD for appointments
  - findOne
  - findAll
  - create
  - update
  - delete
- Updated import and export syntax from ES5 to ES6 in all server files
- Moved routes into a main config route to make things more modularized and easier to follow
- Hook up controllers with express app
- Create interface directory to store more interfaces
- Add bcrypt dependency
- Removed authenticate middleware from Appointment routes. Import still works, but no sense in activating them in the routes in right now until valid users are ready.